### PR TITLE
PR_erlang-p1-yconf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,19 @@
+arch:
+  - ppc64le
+  - amd64
 language: erlang
+before_install:
+  - if [ "$TRAVIS_ARCH" = "ppc64le" ]; then sudo apt-get update; sudo apt-get install rebar; fi
+
 
 otp_release:
   - 19.3
   - 22.3
+# Disable otp_release 18.3 & 19.3 as these releases are not supported on Ubuntu16.04 for arch: ppc64le
+jobs: 
+ exclude:
+  - arch: ppc64le
+    otp_release: 19.3
 
 install:
   - sudo apt-get -qq install libyaml-dev


### PR DESCRIPTION
Disabling otp_release 18.3 & 19.3 as these releases are not supported on Ubuntu16.04 for arch: ppc64le.

Adding power support ppc64le

This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3.

Excluding Jobs for otp_releases: 19.3 as the same is not supported on Ubuntu16.04 with arch: ppc64le
Please refer to the link: https://docs.travis-ci.com/user/languages/erlang/#otprelease-versions

The build is successful for rest all(including arch: ppc64le/amd64).